### PR TITLE
Support more KMP targets

### DIFF
--- a/.github/workflows/test-lib.yml
+++ b/.github/workflows/test-lib.yml
@@ -35,3 +35,15 @@ jobs:
         with:
           check_name: Unit Test Report
           report_paths: 'build/test-results/jvmTest/TEST-*.xml'
+
+  compile-supported-targets:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        target: [jvm, iosX64, iosArm64, macosX64, macosArm64, linuxX64, linuxArm64, mingwX64]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Compile target
+        run: ./gradlew compileKotlin${{ matrix.target }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,6 +20,9 @@ kotlin {
     iosArm64()
     macosX64()
     macosArm64()
+    linuxX64()
+    linuxArm64()
+    mingwX64()
 
     sourceSets {
         val jvmTest by getting {


### PR DESCRIPTION
If we want to use this project in [`kmp-lokalise-api`](https://github.com/ioki-mobility/kmp-lokalise-api), we need support for linux and mingw.
See also https://github.com/ioki-mobility/kmp-lokalise-api/pull/100

Shouldn't hurt I guess 🤷 🙃 