### PR TITLE
add iosSimulator

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,6 +18,7 @@ kotlin {
     jvm()
     iosX64()
     iosArm64()
+    iosSimulatorArm64()
     macosX64()
     macosArm64()
     linuxX64()


### PR DESCRIPTION
closes #15 

This PR adds the ios simulator target. This is needed to export this library in the ios framework when you want to use it in swift code. And your app also targets the simulator.